### PR TITLE
Private pydantic attributes

### DIFF
--- a/langchain/chains/api/base.py
+++ b/langchain/chains/api/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field, root_validator
+from pydantic import Field, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import (
@@ -24,8 +24,8 @@ class APIChain(Chain):
     api_answer_chain: LLMChain
     requests_wrapper: TextRequestsWrapper = Field(exclude=True)
     api_docs: str
-    question_key: str = "question"  #: :meta private:
-    output_key: str = "output"  #: :meta private:
+    question_key: str = PrivateAttr("question")
+    output_key: str = PrivateAttr("output")
 
     @property
     def input_keys(self) -> List[str]:

--- a/langchain/chains/api/openapi/chain.py
+++ b/langchain/chains/api/openapi/chain.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, NamedTuple, Optional, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 from requests import Response
 
 from langchain.base_language import BaseLanguageModel
@@ -34,9 +34,9 @@ class OpenAPIEndpointChain(Chain, BaseModel):
     requests: Requests = Field(exclude=True, default_factory=Requests)
     param_mapping: _ParamMapping = Field(alias="param_mapping")
     return_intermediate_steps: bool = False
-    instructions_key: str = "instructions"  #: :meta private:
-    output_key: str = "output"  #: :meta private:
-    max_text_length: Optional[int] = Field(ge=0)  #: :meta private:
+    instructions_key: str = PrivateAttr("instructions")
+    output_key: str = PrivateAttr("output")
+    max_text_length: Optional[int] = PrivateAttr(Field(ge=0))
 
     @property
     def input_keys(self) -> List[str]:

--- a/langchain/chains/combine_documents/base.py
+++ b/langchain/chains/combine_documents/base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForChainRun,
@@ -36,8 +36,8 @@ def format_document(doc: Document, prompt: BasePromptTemplate) -> str:
 class BaseCombineDocumentsChain(Chain, ABC):
     """Base interface for chains combining documents."""
 
-    input_key: str = "input_documents"  #: :meta private:
-    output_key: str = "output_text"  #: :meta private:
+    input_key: str = PrivateAttr("input_documents")
+    output_key: str = PrivateAttr("output_text")
 
     @property
     def input_keys(self) -> List[str]:
@@ -106,7 +106,7 @@ class BaseCombineDocumentsChain(Chain, ABC):
 class AnalyzeDocumentChain(Chain):
     """Chain that splits documents, then analyzes it in pieces."""
 
-    input_key: str = "input_document"  #: :meta private:
+    input_key: str = PrivateAttr("input_document")
     text_splitter: TextSplitter = Field(default_factory=RecursiveCharacterTextSplitter)
     combine_docs_chain: BaseCombineDocumentsChain
 

--- a/langchain/chains/conversation/base.py
+++ b/langchain/chains/conversation/base.py
@@ -1,7 +1,7 @@
 """Chain that carries on a conversation and calls an LLM."""
 from typing import Dict, List
 
-from pydantic import Extra, Field, root_validator
+from pydantic import Extra, Field, PrivateAttr, root_validator
 
 from langchain.chains.conversation.prompt import PROMPT
 from langchain.chains.llm import LLMChain
@@ -25,8 +25,8 @@ class ConversationChain(LLMChain):
     prompt: BasePromptTemplate = PROMPT
     """Default conversation prompt to use."""
 
-    input_key: str = "input"  #: :meta private:
-    output_key: str = "response"  #: :meta private:
+    input_key: str = PrivateAttr("input")
+    output_key: str = PrivateAttr("response")
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/chains/graph_qa/base.py
+++ b/langchain/chains/graph_qa/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field
+from pydantic import Field, PrivateAtt
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -20,8 +20,8 @@ class GraphQAChain(Chain):
     graph: NetworkxEntityGraph = Field(exclude=True)
     entity_extraction_chain: LLMChain
     qa_chain: LLMChain
-    input_key: str = "query"  #: :meta private:
-    output_key: str = "result"  #: :meta private:
+    input_key: str = PrivateAttr("query")
+    output_key: str = PrivateAttr("result")
 
     @property
     def input_keys(self) -> List[str]:

--- a/langchain/chains/graph_qa/cypher.py
+++ b/langchain/chains/graph_qa/cypher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -31,8 +31,8 @@ class GraphCypherQAChain(Chain):
     graph: Neo4jGraph = Field(exclude=True)
     cypher_generation_chain: LLMChain
     qa_chain: LLMChain
-    input_key: str = "query"  #: :meta private:
-    output_key: str = "result"  #: :meta private:
+    input_key: str = PrivateAttr("query")
+    output_key: str = PrivateAttr("result")
 
     @property
     def input_keys(self) -> List[str]:

--- a/langchain/chains/graph_qa/nebulagraph.py
+++ b/langchain/chains/graph_qa/nebulagraph.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -20,8 +20,8 @@ class NebulaGraphQAChain(Chain):
     graph: NebulaGraph = Field(exclude=True)
     ngql_generation_chain: LLMChain
     qa_chain: LLMChain
-    input_key: str = "query"  #: :meta private:
-    output_key: str = "result"  #: :meta private:
+    input_key: str = PrivateAttr("query")
+    output_key: str = PrivateAttr("result")
 
     @property
     def input_keys(self) -> List[str]:

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-from pydantic import Extra
+from pydantic import Extra, PrivateAttr
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import (
@@ -37,7 +37,7 @@ class LLMChain(Chain):
     prompt: BasePromptTemplate
     """Prompt object to use."""
     llm: BaseLanguageModel
-    output_key: str = "text"  #: :meta private:
+    output_key: str = PrivateAttr("text")
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/chains/llm_bash/base.py
+++ b/langchain/chains/llm_bash/base.py
@@ -5,7 +5,7 @@ import logging
 import warnings
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, Field, root_validator
+from pydantic import Extra, Field, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -32,8 +32,8 @@ class LLMBashChain(Chain):
     llm_chain: LLMChain
     llm: Optional[BaseLanguageModel] = None
     """[Deprecated] LLM wrapper to use."""
-    input_key: str = "question"  #: :meta private:
-    output_key: str = "answer"  #: :meta private:
+    input_key: str = PrivateAttr("question")
+    output_key: str = PrivateAttr("answer")
     prompt: BasePromptTemplate = PROMPT
     """[Deprecated]"""
     bash_process: BashProcess = Field(default_factory=BashProcess)  #: :meta private:

--- a/langchain/chains/llm_checker/base.py
+++ b/langchain/chains/llm_checker/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -85,8 +85,8 @@ class LLMCheckerChain(Chain):
     """[Deprecated]"""
     revised_answer_prompt: PromptTemplate = REVISED_ANSWER_PROMPT
     """[Deprecated] Prompt to use when questioning the documents."""
-    input_key: str = "query"  #: :meta private:
-    output_key: str = "result"  #: :meta private:
+    input_key: str = PrivateAttr("query")
+    output_key: str = PrivateAttr("result")
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/chains/llm_math/base.py
+++ b/langchain/chains/llm_math/base.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Any, Dict, List, Optional
 
 import numexpr
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import (
@@ -35,8 +35,8 @@ class LLMMathChain(Chain):
     """[Deprecated] LLM wrapper to use."""
     prompt: BasePromptTemplate = PROMPT
     """[Deprecated] Prompt to use to translate to python if necessary."""
-    input_key: str = "question"  #: :meta private:
-    output_key: str = "answer"  #: :meta private:
+    input_key: str = PrivateAttr("question")
+    output_key: str = PrivateAttr("answer")
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/chains/llm_requests.py
+++ b/langchain/chains/llm_requests.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, Field, root_validator
+from pydantic import Extra, Field, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForChainRun
 from langchain.chains import LLMChain
@@ -23,9 +23,9 @@ class LLMRequestsChain(Chain):
         default_factory=TextRequestsWrapper, exclude=True
     )
     text_length: int = 8000
-    requests_key: str = "requests_result"  #: :meta private:
-    input_key: str = "url"  #: :meta private:
-    output_key: str = "output"  #: :meta private:
+    requests_key: str = PrivateAttr("requests_result")
+    input_key: str = PrivateAttr("url")
+    output_key: str = PrivateAttr("output")
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/chains/llm_summarization_checker/base.py
+++ b/langchain/chains/llm_summarization_checker/base.py
@@ -6,7 +6,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -97,8 +97,8 @@ class LLMSummarizationCheckerChain(Chain):
     are_all_true_prompt: PromptTemplate = ARE_ALL_TRUE_PROMPT
     """[Deprecated]"""
 
-    input_key: str = "query"  #: :meta private:
-    output_key: str = "result"  #: :meta private:
+    input_key: str = PrivateAttr("query")
+    output_key: str = PrivateAttr("result")
     max_checks: int = 2
     """Maximum number of times to check the assertions. Default to double-checking."""
 

--- a/langchain/chains/mapreduce.py
+++ b/langchain/chains/mapreduce.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Mapping, Optional
 
-from pydantic import Extra
+from pydantic import Extra, PrivateAttr
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun, Callbacks
@@ -28,8 +28,8 @@ class MapReduceChain(Chain):
     """Chain to use to combine documents."""
     text_splitter: TextSplitter
     """Text splitter to use."""
-    input_key: str = "input_text"  #: :meta private:
-    output_key: str = "output_text"  #: :meta private:
+    input_key: str = PrivateAttr("input_text")
+    output_key: str = PrivateAttr("output_text")
 
     @classmethod
     def from_params(

--- a/langchain/chains/moderation.py
+++ b/langchain/chains/moderation.py
@@ -1,7 +1,7 @@
 """Pass input through a moderation endpoint."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import root_validator
+from pydantic import PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForChainRun
 from langchain.chains.base import Chain
@@ -24,13 +24,13 @@ class OpenAIModerationChain(Chain):
             moderation = OpenAIModerationChain()
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_name: Optional[str] = None
     """Moderation model name to use."""
     error: bool = False
     """Whether or not to error if bad content was found."""
-    input_key: str = "input"  #: :meta private:
-    output_key: str = "output"  #: :meta private:
+    input_key: str = PrivateAttr("input")
+    output_key: str = PrivateAttr("output")
     openai_api_key: Optional[str] = None
     openai_organization: Optional[str] = None
 

--- a/langchain/chains/natbot/base.py
+++ b/langchain/chains/natbot/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -29,10 +29,10 @@ class NatBotChain(Chain):
     """Objective that NatBot is tasked with completing."""
     llm: Optional[BaseLanguageModel] = None
     """[Deprecated] LLM wrapper to use."""
-    input_url_key: str = "url"  #: :meta private:
-    input_browser_content_key: str = "browser_content"  #: :meta private:
-    previous_command: str = ""  #: :meta private:
-    output_key: str = "command"  #: :meta private:
+    input_url_key: str = PrivateAttr("url")
+    input_browser_content_key: str = PrivateAttr("browser_content")
+    previous_command: str = PrivateAttr("")
+    output_key: str = PrivateAttr("command")
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/chains/pal/base.py
+++ b/langchain/chains/pal/base.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -31,7 +31,7 @@ class PALChain(Chain):
     get_answer_expr: str = "print(solution())"
     python_globals: Optional[Dict[str, Any]] = None
     python_locals: Optional[Dict[str, Any]] = None
-    output_key: str = "result"  #: :meta private:
+    output_key: str = PrivateAttr("result")
     return_intermediate_steps: bool = False
 
     class Config:

--- a/langchain/chains/qa_with_sources/base.py
+++ b/langchain/chains/qa_with_sources/base.py
@@ -6,7 +6,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import (
@@ -33,10 +33,10 @@ class BaseQAWithSourcesChain(Chain, ABC):
 
     combine_documents_chain: BaseCombineDocumentsChain
     """Chain to use to combine documents."""
-    question_key: str = "question"  #: :meta private:
-    input_docs_key: str = "docs"  #: :meta private:
-    answer_key: str = "answer"  #: :meta private:
-    sources_answer_key: str = "sources"  #: :meta private:
+    question_key: str = PrivateAttr("question")
+    input_docs_key: str = PrivateAttr("docs")
+    answer_key: str = PrivateAttr("answer")
+    sources_answer_key: str = PrivateAttr("sources")
     return_source_documents: bool = False
     """Return the source documents."""
 
@@ -170,7 +170,7 @@ class BaseQAWithSourcesChain(Chain, ABC):
 class QAWithSourcesChain(BaseQAWithSourcesChain):
     """Question answering with sources over documents."""
 
-    input_docs_key: str = "docs"  #: :meta private:
+    input_docs_key: str = PrivateAttr("docs")
 
     @property
     def input_keys(self) -> List[str]:

--- a/langchain/chains/retrieval_qa/base.py
+++ b/langchain/chains/retrieval_qa/base.py
@@ -5,7 +5,7 @@ import warnings
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, Field, root_validator
+from pydantic import Extra, Field, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import (
@@ -26,8 +26,8 @@ from langchain.vectorstores.base import VectorStore
 class BaseRetrievalQA(Chain):
     combine_documents_chain: BaseCombineDocumentsChain
     """Chain to use to combine the documents."""
-    input_key: str = "query"  #: :meta private:
-    output_key: str = "result"  #: :meta private:
+    input_key: str = PrivateAttr("query")
+    output_key: str = PrivateAttr("result")
     return_source_documents: bool = False
     """Return the source documents."""
 

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -1,7 +1,7 @@
 """Chain pipeline where the outputs of one step feed directly into next."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForChainRun,
@@ -16,7 +16,7 @@ class SequentialChain(Chain):
 
     chains: List[Chain]
     input_variables: List[str]
-    output_variables: List[str]  #: :meta private:
+    output_variables: List[str] = PrivateAttr()
     return_all: bool = False
 
     class Config:
@@ -124,8 +124,8 @@ class SimpleSequentialChain(Chain):
 
     chains: List[Chain]
     strip_outputs: bool = False
-    input_key: str = "input"  #: :meta private:
-    output_key: str = "output"  #: :meta private:
+    input_key: str = PrivateAttr("input")
+    output_key: str = PrivateAttr("output")
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, Field, root_validator
+from pydantic import Extra, Field, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -39,14 +39,14 @@ class SQLDatabaseChain(Chain):
     """[Deprecated] Prompt to use to translate natural language to SQL."""
     top_k: int = 5
     """Number of results to return from the query"""
-    input_key: str = "query"  #: :meta private:
-    output_key: str = "result"  #: :meta private:
+    input_key: str = PrivateAttr("query")
+    output_key: str = PrivateAttr("result")
     return_intermediate_steps: bool = False
     """Whether or not to return the intermediate steps along with the final answer."""
     return_direct: bool = False
     """Whether or not to return the result of querying the SQL table directly."""
     use_query_checker: bool = False
-    """Whether or not the query checker tool should be used to attempt 
+    """Whether or not the query checker tool should be used to attempt
     to fix the initial SQL from the LLM."""
     query_checker_prompt: Optional[BasePromptTemplate] = None
     """The prompt template that should be used by the query checker"""
@@ -209,8 +209,8 @@ class SQLDatabaseSequentialChain(Chain):
 
     decider_chain: LLMChain
     sql_chain: SQLDatabaseChain
-    input_key: str = "query"  #: :meta private:
-    output_key: str = "result"  #: :meta private:
+    input_key: str = PrivateAttr("query")
+    output_key: str = PrivateAttr("result")
     return_intermediate_steps: bool = False
 
     @classmethod

--- a/langchain/chat_models/google_palm.py
+++ b/langchain/chat_models/google_palm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, PrivateAttr, root_validator
 from tenacity import (
     before_sleep_log,
     retry,
@@ -229,7 +229,7 @@ class ChatGooglePalm(BaseChatModel, BaseModel):
 
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_name: str = "models/chat-bison-001"
     """Model name to use."""
     google_api_key: Optional[str] = None

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
 )
 
-from pydantic import Extra, Field, root_validator
+from pydantic import Extra, Field, PrivateAttr, root_validator
 from tenacity import (
     before_sleep_log,
     retry,
@@ -136,7 +136,7 @@ class ChatOpenAI(BaseChatModel):
             openai = ChatOpenAI(model_name="gpt-3.5-turbo")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_name: str = Field(default="gpt-3.5-turbo", alias="model")
     """Model name to use."""
     temperature: float = 0.7
@@ -144,7 +144,7 @@ class ChatOpenAI(BaseChatModel):
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Holds any model parameters valid for `create` call not explicitly specified."""
     openai_api_key: Optional[str] = None
-    """Base URL path for API requests, 
+    """Base URL path for API requests,
     leave blank if not using a proxy or service emulator."""
     openai_api_base: Optional[str] = None
     openai_organization: Optional[str] = None

--- a/langchain/embeddings/aleph_alpha.py
+++ b/langchain/embeddings/aleph_alpha.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, PrivateAttr, root_validator
 
 from langchain.embeddings.base import Embeddings
 from langchain.utils import get_from_dict_or_env
@@ -29,7 +29,7 @@ class AlephAlphaAsymmetricSemanticEmbedding(BaseModel, Embeddings):
 
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
 
     model: Optional[str] = "luminous-base"
     """Model name to use."""
@@ -38,13 +38,13 @@ class AlephAlphaAsymmetricSemanticEmbedding(BaseModel, Embeddings):
     normalize: Optional[bool] = True
     """Should returned embeddings be normalized"""
     compress_to_size: Optional[int] = 128
-    """Should the returned embeddings come back as an original 5120-dim vector, 
+    """Should the returned embeddings come back as an original 5120-dim vector,
     or should it be compressed to 128-dim."""
     contextual_control_threshold: Optional[int] = None
-    """Attention control parameters only apply to those tokens that have 
+    """Attention control parameters only apply to those tokens that have
     explicitly been set in the request."""
     control_log_additive: Optional[bool] = True
-    """Apply controls on prompt items by adding the log(control_factor) 
+    """Apply controls on prompt items by adding the log(control_factor)
     to attention scores."""
     aleph_alpha_api_key: Optional[str] = None
     """API key for Aleph Alpha API."""

--- a/langchain/embeddings/bedrock.py
+++ b/langchain/embeddings/bedrock.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.embeddings.base import Embeddings
 
@@ -26,7 +26,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
         .. code-block:: python
 
             from langchain.bedrock_embeddings import BedrockEmbeddings
-            
+
             region_name ="us-east-1"
             credentials_profile_name = "default"
             model_id = "amazon.titan-e1t-medium"
@@ -38,7 +38,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             )
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
 
     region_name: Optional[str] = None
     """The aws region e.g., `us-west-2`. Fallsback to AWS_DEFAULT_REGION env variable

--- a/langchain/embeddings/cohere.py
+++ b/langchain/embeddings/cohere.py
@@ -1,7 +1,7 @@
 """Wrapper around Cohere embedding models."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.embeddings.base import Embeddings
 from langchain.utils import get_from_dict_or_env
@@ -23,7 +23,7 @@ class CohereEmbeddings(BaseModel, Embeddings):
             )
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model: str = "embed-english-v2.0"
     """Model name to use."""
 

--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -1,7 +1,7 @@
 """Wrapper around HuggingFace embedding models."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.embeddings.base import Embeddings
 
@@ -33,11 +33,11 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
             )
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_name: str = DEFAULT_MODEL_NAME
     """Model name to use."""
     cache_folder: Optional[str] = None
-    """Path to store models. 
+    """Path to store models.
     Can be also set by SENTENCE_TRANSFORMERS_HOME environment variable."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Key word arguments to pass to the model."""
@@ -113,11 +113,11 @@ class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
             )
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_name: str = DEFAULT_INSTRUCT_MODEL
     """Model name to use."""
     cache_folder: Optional[str] = None
-    """Path to store models. 
+    """Path to store models.
     Can be also set by SENTENCE_TRANSFORMERS_HOME environment variable."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Key word arguments to pass to the model."""

--- a/langchain/embeddings/huggingface_hub.py
+++ b/langchain/embeddings/huggingface_hub.py
@@ -1,7 +1,7 @@
 """Wrapper around HuggingFace Hub embedding models."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.embeddings.base import Embeddings
 from langchain.utils import get_from_dict_or_env
@@ -29,7 +29,7 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
             )
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     repo_id: str = DEFAULT_REPO_ID
     """Model name to use."""
     task: Optional[str] = "feature-extraction"

--- a/langchain/embeddings/jina.py
+++ b/langchain/embeddings/jina.py
@@ -4,14 +4,14 @@ import os
 from typing import Any, Dict, List, Optional
 
 import requests
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, PrivateAttr, root_validator
 
 from langchain.embeddings.base import Embeddings
 from langchain.utils import get_from_dict_or_env
 
 
 class JinaEmbeddings(BaseModel, Embeddings):
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
 
     model_name: str = "ViT-B-32::openai"
     """Model name to use."""

--- a/langchain/embeddings/llamacpp.py
+++ b/langchain/embeddings/llamacpp.py
@@ -1,7 +1,7 @@
 """Wrapper around llama.cpp embedding models."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, Field, root_validator
+from pydantic import BaseModel, Extra, Field, PrivateAttr, root_validator
 
 from langchain.embeddings.base import Embeddings
 
@@ -20,14 +20,14 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
             llama = LlamaCppEmbeddings(model_path="/path/to/model.bin")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_path: str
 
     n_ctx: int = Field(512, alias="n_ctx")
     """Token context window."""
 
     n_parts: int = Field(-1, alias="n_parts")
-    """Number of parts to split the model into. 
+    """Number of parts to split the model into.
     If -1, the number of parts is automatically determined."""
 
     seed: int = Field(-1, alias="seed")
@@ -46,7 +46,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
     """Force system to keep model in RAM."""
 
     n_threads: Optional[int] = Field(None, alias="n_threads")
-    """Number of threads to use. If None, the number 
+    """Number of threads to use. If None, the number
     of threads is automatically determined."""
 
     n_batch: Optional[int] = Field(8, alias="n_batch")

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 import numpy as np
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 from tenacity import (
     before_sleep_log,
     retry,
@@ -105,7 +105,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
 
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model: str = "text-embedding-ada-002"
     deployment: str = model  # to support Azure OpenAI Service custom deployment names
     openai_api_version: Optional[str] = None

--- a/langchain/embeddings/sagemaker_endpoint.py
+++ b/langchain/embeddings/sagemaker_endpoint.py
@@ -1,7 +1,7 @@
 """Wrapper around Sagemaker InvokeEndpoint API."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.embeddings.base import Embeddings
 from langchain.llms.sagemaker_endpoint import ContentHandlerBase
@@ -49,7 +49,7 @@ class SagemakerEndpointEmbeddings(BaseModel, Embeddings):
                 credentials_profile_name=credentials_profile_name
             )
     """
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
 
     endpoint_name: str = ""
     """The name of the endpoint from the deployed Sagemaker model.

--- a/langchain/embeddings/self_hosted_hugging_face.py
+++ b/langchain/embeddings/self_hosted_hugging_face.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Callable, List, Optional
 
 from langchain.embeddings.self_hosted import SelfHostedEmbeddings
+from pydantic import PrivateAttr
 
 DEFAULT_MODEL_NAME = "sentence-transformers/all-mpnet-base-v2"
 DEFAULT_INSTRUCT_MODEL = "hkunlp/instructor-large"
@@ -77,7 +78,7 @@ class SelfHostedHuggingFaceEmbeddings(SelfHostedEmbeddings):
             hf = SelfHostedHuggingFaceEmbeddings(model_name=model_name, hardware=gpu)
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_id: str = DEFAULT_MODEL_NAME
     """Model name to use."""
     model_reqs: List[str] = ["./", "sentence_transformers", "torch"]

--- a/langchain/embeddings/tensorflow_hub.py
+++ b/langchain/embeddings/tensorflow_hub.py
@@ -1,7 +1,7 @@
 """Wrapper around TensorflowHub embedding models."""
 from typing import Any, List
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, PrivateAttr, Extra
 
 from langchain.embeddings.base import Embeddings
 
@@ -21,7 +21,7 @@ class TensorflowHubEmbeddings(BaseModel, Embeddings):
             tf = TensorflowHubEmbeddings(model_url=url)
     """
 
-    embed: Any  #: :meta private:
+    embed: Any = PrivateAttr()
     model_url: str = DEFAULT_MODEL_URL
     """Model name to use."""
 

--- a/langchain/experimental/generative_agents/generative_agent.py
+++ b/langchain/experimental/generative_agents/generative_agent.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from langchain import LLMChain
 from langchain.base_language import BaseLanguageModel
@@ -27,10 +27,10 @@ class GenerativeAgent(BaseModel):
     llm: BaseLanguageModel
     """The underlying language model."""
     verbose: bool = False
-    summary: str = ""  #: :meta private:
+    summary: str = PrivateAttr("")
     """Stateful self-summary generated via reflection on the character's memory."""
 
-    summary_refresh_seconds: int = 3600  #: :meta private:
+    summary_refresh_seconds: int = PrivateAttr(3600)
     """How frequently to re-generate the summary."""
 
     last_refreshed: datetime = Field(default_factory=datetime.now)  # : :meta private:
@@ -79,7 +79,7 @@ class GenerativeAgent(BaseModel):
 {q1}?
 Context from memory:
 {relevant_memories}
-Relevant context: 
+Relevant context:
 """
         )
         entity_name = self._get_entity_from_observation(observation)

--- a/langchain/experimental/generative_agents/memory.py
+++ b/langchain/experimental/generative_agents/memory.py
@@ -9,6 +9,7 @@ from langchain.prompts import PromptTemplate
 from langchain.retrievers import TimeWeightedVectorStoreRetriever
 from langchain.schema import BaseMemory, Document
 from langchain.utils import mock_now
+from pydantic import PrivateAttr
 
 logger = logging.getLogger(__name__)
 
@@ -32,12 +33,12 @@ class GenerativeAgentMemory(BaseMemory):
     importance_weight: float = 0.15
     """How much weight to assign the memory importance."""
 
-    aggregate_importance: float = 0.0  # : :meta private:
+    aggregate_importance: float = PrivateAttr(0.0)
     """Track the sum of the 'importance' of recent memories.
 
     Triggers reflection when it reaches reflection_threshold."""
 
-    max_tokens_limit: int = 1200  # : :meta private:
+    max_tokens_limit: int = PrivateAttr(1200)
     # input keys
     queries_key: str = "queries"
     most_recent_memories_token_key: str = "recent_memories_token"

--- a/langchain/llms/aleph_alpha.py
+++ b/langchain/llms/aleph_alpha.py
@@ -1,7 +1,7 @@
 """Wrapper around Aleph Alpha APIs."""
 from typing import Any, Dict, List, Optional, Sequence
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -26,7 +26,7 @@ class AlephAlpha(LLM):
             alpeh_alpha = AlephAlpha(aleph_alpha_api_key="my-api-key")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model: Optional[str] = "luminous-base"
     """Model name to use."""
 

--- a/langchain/llms/anthropic.py
+++ b/langchain/llms/anthropic.py
@@ -3,7 +3,7 @@ import re
 import warnings
 from typing import Any, Callable, Dict, Generator, List, Mapping, Optional, Tuple, Union
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
@@ -14,7 +14,7 @@ from langchain.utils import get_from_dict_or_env
 
 
 class _AnthropicCommon(BaseModel):
-    client: Any = None  #: :meta private:
+    client: Any = PrivateAttr()
     model: str = "claude-v1"
     """Model name to use."""
 

--- a/langchain/llms/bedrock.py
+++ b/langchain/llms/bedrock.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Mapping, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -67,13 +67,13 @@ class Bedrock(LLM):
             from bedrock_langchain.bedrock_llm import BedrockLLM
 
             llm = BedrockLLM(
-                credentials_profile_name="default", 
+                credentials_profile_name="default",
                 model_id="amazon.titan-tg1-large"
             )
 
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
 
     region_name: Optional[str] = None
     """The aws region e.g., `us-west-2`. Fallsback to AWS_DEFAULT_REGION env variable

--- a/langchain/llms/cohere.py
+++ b/langchain/llms/cohere.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 from tenacity import (
     before_sleep_log,
     retry,
@@ -62,7 +62,7 @@ class Cohere(LLM):
             cohere = Cohere(model="gptd-instruct-tft", cohere_api_key="my-api-key")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model: Optional[str] = None
     """Model name to use."""
 

--- a/langchain/llms/ctransformers.py
+++ b/langchain/llms/ctransformers.py
@@ -1,7 +1,7 @@
 """Wrapper around the C Transformers library."""
 from typing import Any, Dict, Optional, Sequence
 
-from pydantic import root_validator
+from pydantic import PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -21,7 +21,7 @@ class CTransformers(LLM):
             llm = CTransformers(model="/path/to/ggml-gpt-2.bin", model_type="gpt2")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
 
     model: str
     """The path to a model file or directory or the name of a Hugging Face Hub

--- a/langchain/llms/google_palm.py
+++ b/langchain/llms/google_palm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, PrivateAttr, root_validator
 from tenacity import (
     before_sleep_log,
     retry,
@@ -77,7 +77,7 @@ def _strip_erroneous_leading_spaces(text: str) -> str:
 
 
 class GooglePalm(BaseLLM, BaseModel):
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     google_api_key: Optional[str]
     model_name: str = "models/text-bison-001"
     """Model name to use."""

--- a/langchain/llms/gpt4all.py
+++ b/langchain/llms/gpt4all.py
@@ -2,7 +2,7 @@
 from functools import partial
 from typing import Any, Dict, List, Mapping, Optional, Set
 
-from pydantic import Extra, Field, root_validator
+from pydantic import Extra, Field, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -34,7 +34,7 @@ class GPT4All(LLM):
     """Token context window."""
 
     n_parts: int = Field(-1, alias="n_parts")
-    """Number of parts to split the model into. 
+    """Number of parts to split the model into.
     If -1, the number of parts is automatically determined."""
 
     seed: int = Field(0, alias="seed")
@@ -95,7 +95,7 @@ class GPT4All(LLM):
     allow_download: bool = False
     """If model does not exist in ~/.cache/gpt4all/, download it."""
 
-    client: Any = None  #: :meta private:
+    client: Any = PrivateAttr(None)
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/llms/huggingface_hub.py
+++ b/langchain/llms/huggingface_hub.py
@@ -1,7 +1,7 @@
 """Wrapper around HuggingFace APIs."""
 from typing import Any, Dict, List, Mapping, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -28,7 +28,7 @@ class HuggingFaceHub(LLM):
             hf = HuggingFaceHub(repo_id="gpt2", huggingfacehub_api_token="my-api-key")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     repo_id: str = DEFAULT_REPO_ID
     """Model name to use."""
     task: Optional[str] = None

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -3,7 +3,7 @@ import importlib.util
 import logging
 from typing import Any, List, Mapping, Optional
 
-from pydantic import Extra
+from pydantic import Extra, PrivateAttr
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -47,7 +47,7 @@ class HuggingFacePipeline(LLM):
             hf = HuggingFacePipeline(pipeline=pipe)
     """
 
-    pipeline: Any  #: :meta private:
+    pipeline: Any = PrivateAttr
     model_id: str = DEFAULT_MODEL_ID
     """Model name to use."""
     model_kwargs: Optional[dict] = None

--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any, Dict, Generator, List, Optional
 
-from pydantic import Field, root_validator
+from pydantic import Field, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -24,7 +24,7 @@ class LlamaCpp(LLM):
             llm = LlamaCppEmbeddings(model_path="/path/to/llama/model")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_path: str
     """The path to the Llama model file."""
 

--- a/langchain/llms/manifest.py
+++ b/langchain/llms/manifest.py
@@ -1,7 +1,7 @@
 """Wrapper around HazyResearch's Manifest library."""
 from typing import Any, Dict, List, Mapping, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -10,7 +10,7 @@ from langchain.llms.base import LLM
 class ManifestWrapper(LLM):
     """Wrapper around HazyResearch's Manifest library."""
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     llm_kwargs: Optional[Dict] = None
 
     class Config:

--- a/langchain/llms/nlpcloud.py
+++ b/langchain/llms/nlpcloud.py
@@ -1,7 +1,7 @@
 """Wrapper around NLPCloud APIs."""
 from typing import Any, Dict, List, Mapping, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -21,7 +21,7 @@ class NLPCloud(LLM):
             nlpcloud = NLPCloud(model="gpt-neox-20b")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_name: str = "finetuned-gpt-neox-20b"
     """Model name to use."""
     temperature: float = 0.7

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -20,7 +20,7 @@ from typing import (
     Union,
 )
 
-from pydantic import Extra, Field, root_validator
+from pydantic import Extra, Field, PrivateAttr, root_validator
 from tenacity import (
     before_sleep_log,
     retry,
@@ -123,7 +123,7 @@ async def acompletion_with_retry(
 class BaseOpenAI(BaseLLM):
     """Wrapper around OpenAI large language models."""
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_name: str = Field("text-davinci-003", alias="model")
     """Model name to use."""
     temperature: float = 0.7
@@ -654,7 +654,7 @@ class OpenAIChat(BaseLLM):
             openaichat = OpenAIChat(model_name="gpt-3.5-turbo")
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model_name: str = "gpt-3.5-turbo"
     """Model name to use."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)

--- a/langchain/llms/predictionguard.py
+++ b/langchain/llms/predictionguard.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -30,7 +30,7 @@ class PredictionGuard(LLM):
                                     })
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     model: Optional[str] = "MPT-7B-Instruct"
     """Model name to use."""
 

--- a/langchain/llms/rwkv.py
+++ b/langchain/llms/rwkv.py
@@ -5,7 +5,7 @@ Based on https://github.com/saharNooby/rwkv.cpp/blob/master/rwkv/chat_with_bot.p
 """
 from typing import Any, Dict, List, Mapping, Optional, Set
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -62,15 +62,15 @@ class RWKV(LLM, BaseModel):
     max_tokens_per_generation: int = 256
     """Maximum number of tokens to generate."""
 
-    client: Any = None  #: :meta private:
+    client: Any = PrivateAttr(None)
 
-    tokenizer: Any = None  #: :meta private:
+    tokenizer: Any = PrivateAttr(None)
 
-    pipeline: Any = None  #: :meta private:
+    pipeline: Any = PrivateAttr(None)
 
-    model_tokens: Any = None  #: :meta private:
+    model_tokens: Any = PrivateAttr(None)
 
-    model_state: Any = None  #: :meta private:
+    model_state: Any = PrivateAttr(None)
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/llms/sagemaker_endpoint.py
+++ b/langchain/llms/sagemaker_endpoint.py
@@ -2,7 +2,7 @@
 from abc import abstractmethod
 from typing import Any, Dict, Generic, List, Mapping, Optional, TypeVar, Union
 
-from pydantic import Extra, root_validator
+from pydantic import Extra, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -30,7 +30,7 @@ class ContentHandlerBase(Generic[INPUT_TYPE, OUTPUT_TYPE]):
                 def transform_input(self, prompt: str, model_kwargs: Dict) -> bytes:
                     input_str = json.dumps({prompt: prompt, **model_kwargs})
                     return input_str.encode('utf-8')
-                
+
                 def transform_output(self, output: bytes) -> str:
                     response_json = json.loads(output.read().decode("utf-8"))
                     return response_json[0]["generated_text"]
@@ -99,7 +99,7 @@ class SagemakerEndpoint(LLM):
                 credentials_profile_name=credentials_profile_name
             )
     """
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
 
     endpoint_name: str = ""
     """The name of the endpoint from the deployed Sagemaker model.
@@ -135,7 +135,7 @@ class SagemakerEndpoint(LLM):
                 def transform_input(self, prompt: str, model_kwargs: Dict) -> bytes:
                     input_str = json.dumps({prompt: prompt, **model_kwargs})
                     return input_str.encode('utf-8')
-                
+
                 def transform_output(self, output: bytes) -> str:
                     response_json = json.loads(output.read().decode("utf-8"))
                     return response_json[0]["generated_text"]

--- a/langchain/llms/self_hosted.py
+++ b/langchain/llms/self_hosted.py
@@ -4,7 +4,7 @@ import logging
 import pickle
 from typing import Any, Callable, List, Mapping, Optional
 
-from pydantic import Extra
+from pydantic import Extra, PrivateAttr
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -125,9 +125,9 @@ class SelfHostedPipeline(LLM):
             )
     """
 
-    pipeline_ref: Any  #: :meta private:
-    client: Any  #: :meta private:
-    inference_fn: Callable = _generate_text  #: :meta private:
+    pipeline_ref: Any = PrivateAttr()
+    client: Any = PrivateAttr()
+    inference_fn: Callable = PrivateAttr(_generate_text)
     """Inference function to send to the remote hardware."""
     hardware: Any
     """Remote hardware to send the inference function to."""

--- a/langchain/llms/self_hosted_hugging_face.py
+++ b/langchain/llms/self_hosted_hugging_face.py
@@ -3,7 +3,7 @@ import importlib.util
 import logging
 from typing import Any, Callable, List, Mapping, Optional
 
-from pydantic import Extra
+from pydantic import Extra, PrivateAttr
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.self_hosted import SelfHostedPipeline
@@ -167,7 +167,7 @@ class SelfHostedHuggingFaceLLM(SelfHostedPipeline):
     """Requirements to install on hardware to inference the model."""
     model_load_fn: Callable = _load_transformer
     """Function to load the model remotely on the server."""
-    inference_fn: Callable = _generate_text  #: :meta private:
+    inference_fn: Callable = PrivateAttr(_generate_text)
     """Inference function to send to the remote hardware."""
 
     class Config:

--- a/langchain/llms/vertexai.py
+++ b/langchain/llms/vertexai.py
@@ -1,7 +1,7 @@
 """Wrapper around Google VertexAI models."""
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, PrivateAttr, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class _VertexAICommon(BaseModel):
-    client: "_LanguageModel" = None  #: :meta private:
+    client: "_LanguageModel" = PrivateAttr(None)
     model_name: str
     "Model name to use."
     temperature: float = 0.0

--- a/langchain/memory/buffer.py
+++ b/langchain/memory/buffer.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import root_validator
+from pydantic import PrivateAttr, root_validator
 
 from langchain.memory.chat_memory import BaseChatMemory, BaseMemory
 from langchain.memory.utils import get_prompt_input_key
@@ -12,7 +12,7 @@ class ConversationBufferMemory(BaseChatMemory):
 
     human_prefix: str = "Human"
     ai_prefix: str = "AI"
-    memory_key: str = "history"  #: :meta private:
+    memory_key: str = PrivateAttr("history")
 
     @property
     def buffer(self) -> Any:
@@ -48,7 +48,7 @@ class ConversationStringBufferMemory(BaseMemory):
     buffer: str = ""
     output_key: Optional[str] = None
     input_key: Optional[str] = None
-    memory_key: str = "history"  #: :meta private:
+    memory_key: str = PrivateAttr("history")
 
     @root_validator()
     def validate_chains(cls, values: Dict) -> Dict:

--- a/langchain/memory/buffer_window.py
+++ b/langchain/memory/buffer_window.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List
 
 from langchain.memory.chat_memory import BaseChatMemory
 from langchain.schema import BaseMessage, get_buffer_string
+from pydantic import PrivateAttr
 
 
 class ConversationBufferWindowMemory(BaseChatMemory):
@@ -9,7 +10,7 @@ class ConversationBufferWindowMemory(BaseChatMemory):
 
     human_prefix: str = "Human"
     ai_prefix: str = "AI"
-    memory_key: str = "history"  #: :meta private:
+    memory_key: str = PrivateAttr("history")
     k: int = 5
 
     @property

--- a/langchain/memory/kg.py
+++ b/langchain/memory/kg.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Type, Union
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from langchain.base_language import BaseLanguageModel
 from langchain.chains.llm import LLMChain
@@ -36,7 +36,7 @@ class ConversationKGMemory(BaseChatMemory):
     llm: BaseLanguageModel
     summary_message_cls: Type[BaseMessage] = SystemMessage
     """Number of previous utterances to include in the context."""
-    memory_key: str = "history"  #: :meta private:
+    memory_key: str = PrivateAttr("history")
 
     def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Return history buffer."""

--- a/langchain/memory/summary.py
+++ b/langchain/memory/summary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Type
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, PrivateAttr, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.chains.llm import LLMChain
@@ -41,7 +41,7 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin):
     """Conversation summarizer to memory."""
 
     buffer: str = ""
-    memory_key: str = "history"  #: :meta private:
+    memory_key: str = PrivateAttr("history")
 
     @classmethod
     def from_messages(

--- a/langchain/memory/vectorstore.py
+++ b/langchain/memory/vectorstore.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from langchain.memory.chat_memory import BaseMemory
 from langchain.memory.utils import get_prompt_input_key
@@ -16,7 +16,7 @@ class VectorStoreRetrieverMemory(BaseMemory):
     retriever: VectorStoreRetriever = Field(exclude=True)
     """VectorStoreRetriever object to connect to."""
 
-    memory_key: str = "history"  #: :meta private:
+    memory_key: str = PrivateAttr("history")
     """Key name to locate the memories in the result of load_memory_variables."""
 
     input_key: Optional[str] = None

--- a/langchain/output_parsers/regex_dict.py
+++ b/langchain/output_parsers/regex_dict.py
@@ -4,12 +4,13 @@ import re
 from typing import Dict, Optional
 
 from langchain.schema import BaseOutputParser
+from pydantic import PrivateAttr
 
 
 class RegexDictParser(BaseOutputParser):
     """Class to parse the output into a dictionary."""
 
-    regex_pattern: str = r"{}:\s?([^.'\n']*)\.?"  # : :meta private:
+    regex_pattern: str = PrivateAttr(r"{}:\s?([^.'\n']*)\.?")
     output_key_to_format: Dict[str, str]
     no_update_value: Optional[str] = None
 

--- a/langchain/prompts/example_selector/length_based.py
+++ b/langchain/prompts/example_selector/length_based.py
@@ -2,7 +2,7 @@
 import re
 from typing import Callable, Dict, List
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, PrivateAttr, validator
 
 from langchain.prompts.example_selector.base import BaseExampleSelector
 from langchain.prompts.prompt import PromptTemplate
@@ -27,7 +27,7 @@ class LengthBasedExampleSelector(BaseExampleSelector, BaseModel):
     max_length: int = 2048
     """Max length for the prompt, beyond which examples are cut."""
 
-    example_text_lengths: List[int] = []  #: :meta private:
+    example_text_lengths: List[int] = PrivateAttr([])
 
     def add_example(self, example: Dict[str, str]) -> None:
         """Add new example to list."""

--- a/langchain/tools/azure_cognitive_services/form_recognizer.py
+++ b/langchain/tools/azure_cognitive_services/form_recognizer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
-from pydantic import root_validator
+from pydantic import PrivateAttr, root_validator
 
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForToolRun,
@@ -23,9 +23,9 @@ class AzureCogsFormRecognizerTool(BaseTool):
     https://learn.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/quickstarts/get-started-sdks-rest-api?view=form-recog-3.0.0&pivots=programming-language-python
     """
 
-    azure_cogs_key: str = ""  #: :meta private:
-    azure_cogs_endpoint: str = ""  #: :meta private:
-    doc_analysis_client: Any  #: :meta private:
+    azure_cogs_key: str = PrivateAttr("")
+    azure_cogs_endpoint: str = PrivateAttr("")
+    doc_analysis_client: Any = PrivateAttr()
 
     name = "Azure Cognitive Services Form Recognizer"
     description = (

--- a/langchain/tools/azure_cognitive_services/image_analysis.py
+++ b/langchain/tools/azure_cognitive_services/image_analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
-from pydantic import root_validator
+from pydantic import PrivateAttr, root_validator
 
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForToolRun,
@@ -23,10 +23,10 @@ class AzureCogsImageAnalysisTool(BaseTool):
     https://learn.microsoft.com/en-us/azure/cognitive-services/computer-vision/quickstarts-sdk/image-analysis-client-library-40
     """
 
-    azure_cogs_key: str = ""  #: :meta private:
-    azure_cogs_endpoint: str = ""  #: :meta private:
-    vision_service: Any  #: :meta private:
-    analysis_options: Any  #: :meta private:
+    azure_cogs_key: str = PrivateAttr("")
+    azure_cogs_endpoint: str = PrivateAttr("")
+    vision_service: Any = PrivateAttr()
+    analysis_options: Any = PrivateAttr()
 
     name = "Azure Cognitive Services Image Analysis"
     description = (

--- a/langchain/tools/azure_cognitive_services/speech2text.py
+++ b/langchain/tools/azure_cognitive_services/speech2text.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
-from pydantic import root_validator
+from pydantic import PrivateAttr, root_validator
 
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForToolRun,
@@ -27,10 +27,10 @@ class AzureCogsSpeech2TextTool(BaseTool):
     https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-speech-to-text?pivots=programming-language-python
     """
 
-    azure_cogs_key: str = ""  #: :meta private:
-    azure_cogs_region: str = ""  #: :meta private:
-    speech_language: str = "en-US"  #: :meta private:
-    speech_config: Any  #: :meta private:
+    azure_cogs_key: str = PrivateAttr("")
+    azure_cogs_region: str = PrivateAttr("")
+    speech_language: str = PrivateAttr("en-US")
+    speech_config: Any = PrivateAttr()
 
     name = "Azure Cognitive Services Speech2Text"
     description = (

--- a/langchain/tools/azure_cognitive_services/text2speech.py
+++ b/langchain/tools/azure_cognitive_services/text2speech.py
@@ -4,7 +4,7 @@ import logging
 import tempfile
 from typing import Any, Dict, Optional
 
-from pydantic import root_validator
+from pydantic import PrivateAttr, root_validator
 
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForToolRun,
@@ -23,10 +23,10 @@ class AzureCogsText2SpeechTool(BaseTool):
     https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-text-to-speech?pivots=programming-language-python
     """
 
-    azure_cogs_key: str = ""  #: :meta private:
-    azure_cogs_region: str = ""  #: :meta private:
-    speech_language: str = "en-US"  #: :meta private:
-    speech_config: Any  #: :meta private:
+    azure_cogs_key: str = PrivateAttr("")
+    azure_cogs_region: str = PrivateAttr("")
+    speech_language: str = PrivateAttr("en-US")
+    speech_config: Any = PrivateAttr()
 
     name = "Azure Cognitive Services Text2Speech"
     description = (

--- a/langchain/utilities/arxiv.py
+++ b/langchain/utilities/arxiv.py
@@ -32,7 +32,7 @@ class ArxivAPIWrapper(BaseModel):
 
     """
 
-    arxiv_client: Any  #: :meta private:
+    arxiv_search: Any  #: :meta private:
     arxiv_exceptions: Any  # :meta private:
     top_k_results: int = 3
     ARXIV_MAX_QUERY_LENGTH = 300

--- a/langchain/utilities/arxiv.py
+++ b/langchain/utilities/arxiv.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Any, Dict, List
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, root_validator, PrivateAttr
 
 from langchain.schema import Document
 
@@ -32,8 +32,8 @@ class ArxivAPIWrapper(BaseModel):
 
     """
 
-    arxiv_search: Any  #: :meta private:
-    arxiv_exceptions: Any  # :meta private:
+    arxiv_search: Any = PrivateAttr()
+    arxiv_exceptions: Any = PrivateAttr()
     top_k_results: int = 3
     ARXIV_MAX_QUERY_LENGTH = 300
     load_max_docs: int = 100

--- a/langchain/utilities/awslambda.py
+++ b/langchain/utilities/awslambda.py
@@ -2,7 +2,7 @@
 import json
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 
 class LambdaWrapper(BaseModel):
@@ -16,7 +16,7 @@ class LambdaWrapper(BaseModel):
 
     """
 
-    lambda_client: Any  #: :meta private:
+    lambda_client: Any = PrivateAttr()
     function_name: Optional[str] = None
     awslambda_tool_name: Optional[str] = None
     awslambda_tool_description: Optional[str] = None

--- a/langchain/utilities/google_places_api.py
+++ b/langchain/utilities/google_places_api.py
@@ -4,7 +4,7 @@
 import logging
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.utils import get_from_dict_or_env
 
@@ -30,7 +30,7 @@ class GooglePlacesAPIWrapper(BaseModel):
     """
 
     gplaces_api_key: Optional[str] = None
-    google_map_client: Any  #: :meta private:
+    google_map_client: Any = PrivateAttr()
     top_k_results: Optional[int] = None
 
     class Config:

--- a/langchain/utilities/google_search.py
+++ b/langchain/utilities/google_search.py
@@ -1,7 +1,7 @@
 """Util that calls Google Search."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.utils import get_from_dict_or_env
 
@@ -45,7 +45,7 @@ class GoogleSearchAPIWrapper(BaseModel):
     .com
     """
 
-    search_engine: Any  #: :meta private:
+    search_engine: Any = PrivateAttr()
     google_api_key: Optional[str] = None
     google_cse_id: Optional[str] = None
     k: int = 10

--- a/langchain/utilities/graphql.py
+++ b/langchain/utilities/graphql.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Callable, Dict, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 
 class GraphQLAPIWrapper(BaseModel):
@@ -13,8 +13,8 @@ class GraphQLAPIWrapper(BaseModel):
 
     custom_headers: Optional[Dict[str, str]] = None
     graphql_endpoint: str
-    gql_client: Any  #: :meta private:
-    gql_function: Callable[[str], Any]  #: :meta private:
+    gql_client: Any = PrivateAttr()
+    gql_function: Callable[[str], Any] = PrivateAttr()
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/utilities/jira.py
+++ b/langchain/utilities/jira.py
@@ -1,7 +1,7 @@
 """Util that calls Jira."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.tools.jira.prompt import (
     JIRA_CATCH_ALL_PROMPT,
@@ -16,7 +16,7 @@ from langchain.utils import get_from_dict_or_env
 class JiraAPIWrapper(BaseModel):
     """Wrapper for Jira API."""
 
-    jira: Any  #: :meta private:
+    jira: Any = PrivateAttr()
     jira_username: Optional[str] = None
     jira_api_token: Optional[str] = None
     jira_instance_url: Optional[str] = None

--- a/langchain/utilities/serpapi.py
+++ b/langchain/utilities/serpapi.py
@@ -7,7 +7,7 @@ import sys
 from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
-from pydantic import BaseModel, Extra, Field, root_validator
+from pydantic import BaseModel, Extra, Field, PrivateAttr, root_validator
 
 from langchain.utils import get_from_dict_or_env
 
@@ -40,7 +40,7 @@ class SerpAPIWrapper(BaseModel):
             serpapi = SerpAPIWrapper()
     """
 
-    search_engine: Any  #: :meta private:
+    search_engine: Any = PrivateAttr()
     params: dict = Field(
         default={
             "engine": "google",

--- a/langchain/utilities/twilio.py
+++ b/langchain/utilities/twilio.py
@@ -1,7 +1,7 @@
 """Util that calls Twilio."""
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.utils import get_from_dict_or_env
 
@@ -26,20 +26,20 @@ class TwilioAPIWrapper(BaseModel):
             twilio.run('test', '+12484345508')
     """
 
-    client: Any  #: :meta private:
+    client: Any = PrivateAttr()
     account_sid: Optional[str] = None
     """Twilio account string identifier."""
     auth_token: Optional[str] = None
     """Twilio auth token."""
     from_number: Optional[str] = None
-    """A Twilio phone number in [E.164](https://www.twilio.com/docs/glossary/what-e164) 
-        format, an 
-        [alphanumeric sender ID](https://www.twilio.com/docs/sms/send-messages#use-an-alphanumeric-sender-id), 
-        or a [Channel Endpoint address](https://www.twilio.com/docs/sms/channels#channel-addresses) 
-        that is enabled for the type of message you want to send. Phone numbers or 
-        [short codes](https://www.twilio.com/docs/sms/api/short-code) purchased from 
-        Twilio also work here. You cannot, for example, spoof messages from a private 
-        cell phone number. If you are using `messaging_service_sid`, this parameter 
+    """A Twilio phone number in [E.164](https://www.twilio.com/docs/glossary/what-e164)
+        format, an
+        [alphanumeric sender ID](https://www.twilio.com/docs/sms/send-messages#use-an-alphanumeric-sender-id),
+        or a [Channel Endpoint address](https://www.twilio.com/docs/sms/channels#channel-addresses)
+        that is enabled for the type of message you want to send. Phone numbers or
+        [short codes](https://www.twilio.com/docs/sms/api/short-code) purchased from
+        Twilio also work here. You cannot, for example, spoof messages from a private
+        cell phone number. If you are using `messaging_service_sid`, this parameter
         must be empty.
     """  # noqa: E501
 

--- a/langchain/utilities/wikipedia.py
+++ b/langchain/utilities/wikipedia.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.schema import Document
 
@@ -21,7 +21,7 @@ class WikipediaAPIWrapper(BaseModel):
     It limits the Document content by doc_content_chars_max.
     """
 
-    wiki_client: Any  #: :meta private:
+    wiki_client: Any = PrivateAttr()
     top_k_results: int = 3
     lang: str = "en"
     load_all_available_meta: bool = False

--- a/langchain/utilities/wolfram_alpha.py
+++ b/langchain/utilities/wolfram_alpha.py
@@ -1,7 +1,7 @@
 """Util that calls WolframAlpha."""
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 
 from langchain.utils import get_from_dict_or_env
 
@@ -18,7 +18,7 @@ class WolframAlphaAPIWrapper(BaseModel):
 
     """
 
-    wolfram_client: Any  #: :meta private:
+    wolfram_client: Any = PrivateAttr()
     wolfram_alpha_appid: Optional[str] = None
 
     class Config:


### PR DESCRIPTION
Across the codebase, many pydantic attributes are labeled with a special `#: :meta private:` comment to hide them from sphinx rendering.

This comment does not affect the pydantic object, the attributes are still present in the public signature and are still visible to pyright/pylance.  I don't want to litter my code with `client=None` to keep my static checker happy. :smile: 

Pyright provides `PrivateAttr()` function which marks the attribute as private.  These private functions are not shown by sphinx, do not appear in the public signature, ~~are not allowed to be set at initialization~~ are not validated in any way.  This is a perfect match for the intention behind the `#: :meta private:` comments.

They must be renamed to start with a single underscore ('sunder') or a double underscore ('dunder').  These are meant to be private so changing their names should not affect anything outside of the modules.  Note: Gpt4 mislead me on this front and I did not realize I would need to rename all of the private fields to sunder versions.

Private attributes are stored in slots.  They are not checked in any way, so `Field(ge=0)` can not be represented.